### PR TITLE
Adding preview to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # USRSE Logos
 
 This is a repository of logos, presentation templates, and other associated
-branding files for the USRSE oranization.
+branding files for the USRSE organization. Here is a small preview (200x255)
+of the logo:
 
+![png/rse-logo-200x255.png](png/rse-logo-200x255.png)
+
+For other formats and sizes, see the folders below.
 Files should generally be exported from the original [Adobe Illustrator files](ai_files).
 
-Exported files:
+## Exported files:
 
  - [vector](vector) svg files
  - [png](png) png files
  
-Non-logo files:
+## Non-logo files:
 
  - [stickers](stickers) has png versions of printed sticker files
  - [backgrounds](background)
 
-If you would like a resource or have a question, please [open an issue](https://www.github.com/usrse/logo)
+If you would like a resource or have a question, please [open an issue](https://www.github.com/usrse/logo/issues)


### PR DESCRIPTION
This will add a preview of a smaller logo to the README, and instruct the user to explore the different folders for different sizes / formats. The idea is to link to this repository from the main page to make it easier for others to find our resources.
 
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>